### PR TITLE
Additional 'metadata' parameter in resource creation function

### DIFF
--- a/hs_restclient/__init__.py
+++ b/hs_restclient/__init__.py
@@ -555,7 +555,7 @@ class HydroShare(object):
     def createResource(self, resource_type, title, resource_file=None, resource_filename=None,
                        abstract=None, keywords=None,
                        edit_users=None, view_users=None, edit_groups=None, view_groups=None,
-                       progress_callback=None):
+                       metadata=None, progress_callback=None):
         """ Create a new resource.
 
         :param resource_type: string representing the a HydroShare resource type recognized by this
@@ -573,6 +573,7 @@ class HydroShare(object):
         :param view_users: list of HydroShare usernames who will be given view permissions
         :param edit_groups: list of HydroShare group names that will be given edit permissions
         :param view_groups: list of HydroShare group names that will be given view permissions
+        :param metadata: json string data for each of the metadata elements
         :param progress_callback: user-defined function to provide feedback to the user about the progress
             of the upload of resource_file.  For more information, see:
             http://toolbelt.readthedocs.org/en/latest/uploading-data.html#monitoring-your-streaming-multipart-upload
@@ -609,6 +610,9 @@ class HydroShare(object):
             params['edit_groups'] = edit_groups
         if view_groups:
             params['view_groups'] = view_groups
+
+        if metadata:
+            params['metadata'] = metadata
 
         if resource_file:
             close_fd = self._prepareFileForUpload(params, resource_file, resource_filename)

--- a/tests/test_hs_restclient.py
+++ b/tests/test_hs_restclient.py
@@ -14,6 +14,7 @@ import shutil
 from zipfile import ZipFile
 import difflib
 import filecmp
+import json
 
 from httmock import with_httmock, HTTMock
 
@@ -107,10 +108,13 @@ class TestGetResourceList(unittest.TestCase):
         keywords = ('hello', 'world')
         rtype = 'GenericResource'
         fname = 'mocks/data/minimal_resource_file.txt'
+        metadata = json.dumps([{'coverage': {'type': 'period', 'start': '01/01/2000',
+                                             'end': '12/12/2010'}}])
 
         with HTTMock(mocks.hydroshare.createResourceCRUD):
             # Create
-            newres = hs.createResource(rtype, title, resource_file=fname, keywords=keywords, abstract=abstract)
+            newres = hs.createResource(rtype, title, resource_file=fname, keywords=keywords,
+                                       abstract=abstract, metadata=metadata)
             self.assertIsNotNone(newres)
             sysmeta = hs.getSystemMetadata(newres)
             self.assertEqual(sysmeta['resource_id'], newres)


### PR DESCRIPTION
This additional parameter 'metadata' would allow passing data for any valid metadata element including data for resource specific extended metadata when creating a resource.