### PR TITLE
Fix usage of HydroShareHTTPException

### DIFF
--- a/hs_restclient/generators.py
+++ b/hs_restclient/generators.py
@@ -9,7 +9,7 @@ def resultsListGenerator(hs, url, params=None):
         elif r.status_code == 404:
             raise HydroShareNotFound((url,))
         else:
-            raise HydroShareHTTPException((url, 'GET', r.status_code, params))
+            raise HydroShareHTTPException(r)
     res = r.json()
     results = res['results']
     for item in results:
@@ -28,7 +28,7 @@ def resultsListGenerator(hs, url, params=None):
             elif r.status_code == 404:
                 raise HydroShareNotFound((next_url,))
             else:
-                raise HydroShareHTTPException((next_url, 'GET', r.status_code, params))
+                raise HydroShareHTTPException(r)
         res = r.json()
         results = res['results']
         for item in results:


### PR DESCRIPTION
It looks like `generators.py` was not updated to use the latest signature for `HydroShareHTTPException`:

```python

class HydroShareHTTPException(HydroShareException):
    """ Exception used to communicate HTTP errors from HydroShare server

        Arguments in tuple passed to constructor must be: (url, status_code, params).
        url and status_code are of type string, while the optional params argument
        should be a dict.
    """
    def __init__(self, response):
        super(HydroShareHTTPException, self).__init__(response)
        self.url = response.request.url
        self.method = response.request.method
        self.status_code = response.status_code
        self.status_msg = response.text if response.text else "No status message"
```

Passing a tuple (as is currently done) results in the following error:
```bash
File "/home/kyle/anaconda3/envs/scope/lib/python3.8/site-packages/hs_restclient/generators.py", line 12, in resultsListGenerator
        raise HydroShareHTTPException((url, 'GET', r.status_code, params))
      File "/home/kyle/anaconda3/envs/scope/lib/python3.8/site-packages/hs_restclient/exceptions.py", line 61, in __init__
        self.url = response.request.url
    AttributeError: 'tuple' object has no attribute 'request'
```